### PR TITLE
Adds Flubu build script

### DIFF
--- a/HttpReports.sln
+++ b/HttpReports.sln
@@ -57,6 +57,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildScript", "build\BuildScript.csproj", "{DCA4DF60-2CE9-4F7F-8E09-538C27CE6AC9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,10 @@ Global
 		{AFFD2462-0D3C-4642-82B0-8C1F99F8CE9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFFD2462-0D3C-4642-82B0-8C1F99F8CE9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFFD2462-0D3C-4642-82B0-8C1F99F8CE9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCA4DF60-2CE9-4F7F-8E09-538C27CE6AC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCA4DF60-2CE9-4F7F-8E09-538C27CE6AC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCA4DF60-2CE9-4F7F-8E09-538C27CE6AC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCA4DF60-2CE9-4F7F-8E09-538C27CE6AC9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +169,7 @@ Global
 		{D56DBE48-B3ED-40F3-AF26-DAA60037FE6D} = {BAF971BD-0546-4610-A9F6-6F6DC68E6FE7}
 		{82B6DD16-2443-496C-8A07-5A2AA027593F} = {CDCA953E-391F-422A-85A0-2057B8F2ED96}
 		{AFFD2462-0D3C-4642-82B0-8C1F99F8CE9D} = {BAF971BD-0546-4610-A9F6-6F6DC68E6FE7}
+		{DCA4DF60-2CE9-4F7F-8E09-538C27CE6AC9} = {92F075FE-55AD-4A3F-A210-7B019A2DA690}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CF5EB1E6-E330-45DC-80A3-9A2CE692DDE5}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,59 @@
+
+jobs:    
+
+- job: Windows
+  pool:
+    vmImage: 'windows-latest'
+  
+  steps:
+
+  - task: DotNetCoreInstaller@1
+    displayName: install Sdk
+    inputs:
+      version: '3.1.100'      
+
+  - script: dotnet tool install --global FlubuCore.Tool --version 5.1.8
+    displayName: 'install flubu'
+
+  - script: flubu build
+    displayName: Compile
+
+  - script: flubu pack
+    displayName: pack
+
+
+- job: Ubuntu
+  pool:
+    vmImage: 'ubuntu-latest'
+  
+  steps:
+
+  - task: DotNetCoreInstaller@1
+    displayName: install Sdk
+    inputs:
+      version: '3.1.100'      
+
+  - script: dotnet tool install --global FlubuCore.Tool --version 5.1.8
+    displayName: 'install flubu'
+
+  - script: flubu build
+    displayName: Compile
+   
+- job: MacOS
+  pool:
+    vmImage: 'macOS-latest'
+  
+  steps:
+
+  - task: DotNetCoreInstaller@1
+    displayName: install Sdk
+    inputs:
+      version: '3.1.100'      
+
+  - script: dotnet tool install --global FlubuCore.Tool --version 5.1.8
+    displayName: 'install flubu'
+
+  - script: flubu build
+    displayName: Compile
+    workingDirectory: src
+

--- a/build/BuildScript.cs
+++ b/build/BuildScript.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FlubuCore.Context;
+using FlubuCore.Context.Attributes.BuildProperties;
+using FlubuCore.IO;
+using FlubuCore.Scripting;
+
+namespace BuildScript
+{
+    public class BuildScript : DefaultBuildScript
+    {
+        [SolutionFileName] 
+        public string SolutionFileName { get; set; } = "HttpReports.sln";
+
+        [FromArg("c")]
+        [BuildConfiguration]
+        public string Configuration { get; set; } = "Release";
+
+        public FullPath OutputDir => RootDirectory.CombineWith("output");
+
+        public FullPath SourceDir => RootDirectory.CombineWith("src");
+
+        protected override void ConfigureTargets(ITaskContext context)
+        {
+            var clean = context.CreateTarget("Clean")
+                .SetDescription("Clean's the solution")
+                .AddCoreTask(x => x.Clean());
+                
+           var build = context.CreateTarget("Build")
+                .SetDescription("Build's the solution")
+                .DependsOn(clean)
+                .AddCoreTask(x => x.Build());
+
+            var projectsToPack = context.GetFiles(SourceDir, "*/*.csproj");
+
+            context.CreateTarget("Pack")
+                .SetDescription("Packs and publishes nuget package.")
+                .DependsOn(build)
+                .ForEach(projectsToPack, (project, target) =>
+                {
+                    target.AddCoreTask(x => x.Pack()
+                        .Project(project)
+                        .IncludeSymbols()
+                        .NoBuild()
+                        .OutputDirectory(OutputDir));
+                });
+        }
+    }
+}

--- a/build/BuildScript.csproj
+++ b/build/BuildScript.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FlubuCore" Version="5.1.8" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This is just a draft I think we should atleast add:

- Versioning We have 4 options here:
  - Version is stored into a file for example Changelog.md or txt file (See flubu or flubu examples build  
     scripts
  - Version is stored directly in build script
  - GitVersion is used for versioning
  - Props file are used for versioning (see build script in Cap )
- Tests should be added. I won't cover this on azure devops as database is required for running tests. So if you want to run tests on CI you will have to figure out yourself how to do this.
- Publishing of nuget package. This will be added after you decide how would you like to handle versioning 