### PR TITLE
Fix GZip decompress and Support deflate and brotli response stream

### DIFF
--- a/src/HttpReports/HttpReports.csproj
+++ b/src/HttpReports/HttpReports.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.1" />


### PR DESCRIPTION
1. Fix GZip decompress error (context.Request.Body to context.Response.Body)

2. Support deflate and brotli response stream